### PR TITLE
FIX bad MIC compare

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -26,7 +26,7 @@ class Utils
     public static function normalizeMic($mic)
     {
         $parts    = explode(',', $mic, 2);
-        $parts[1] = strtolower(str_replace('-', '', $parts[1]));
+        $parts[1] = trim(strtolower(str_replace('-', '', $parts[1])));
 
         return implode(',', $parts);
     }


### PR DESCRIPTION
The Message Integrity Code (MIC) does not match the sent AS2 message (required: D1l7ktpEpRMq18zd3WT+f4PNWLkvaTboUxG7MTchkps=, sha256, returned: D1l7ktpEpRMq18zd3WT+f4PNWLkvaTboUxG7MTchkps=,sha256)"

it was only a space between the MIC, i suggest to add trim()