### PR TITLE
Fixed 3 bugs

### DIFF
--- a/src/CryptoHelper.php
+++ b/src/CryptoHelper.php
@@ -110,9 +110,7 @@ class CryptoHelper
         $flags |= PKCS7_NOVERIFY;
         // }
 
-        $outFile = stripos(PHP_OS, 'WIN') === 0 ?
-            self::getTempFilename() :
-            '/dev/null';
+        $outFile = self::getTempFilename();
 
         return openssl_pkcs7_verify($data, $flags, $outFile, $rootCerts) === true;
     }

--- a/src/MimePart.php
+++ b/src/MimePart.php
@@ -315,13 +315,14 @@ class MimePart implements PsrMessageInterface
         } else {
             $boundary = $this->getParsedHeader('content-type', 0, 'boundary');
             if ($boundary) {
-                $separator = '--' . preg_quote($boundary, '/');
-                // Get multi-part content
-                if (preg_match('/' . $separator . '\r?\n(.+?)\r?\n' . $separator . '--/s', $body, $matches)) {
-                    $parts = preg_split('/\r?\n' . $separator . '\r?\n/', $matches[1]);
-                    foreach ($parts as $part) {
-                        $this->addPart($part);
-                    }
+                $parts = explode('--' . $boundary, $body);
+                array_shift($parts); // remove unecessary first element
+                array_pop($parts); // remove unecessary last element
+
+                foreach ($parts as $part) {
+                    $part = preg_replace('/^\r?\n|\r?\n$/','',$part);
+
+                    $this->addPart($part);
                 }
             } else {
                 $this->body = $body;

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -32,7 +32,7 @@ class Utils
     }
 
     /**
-     * Return decoded base64, if it is not a base64 string, returns false
+     * Return decoded base64, if it is not a base64 string, returns false.
      *
      * @param string $data
      *
@@ -44,7 +44,7 @@ class Utils
     }
 
     /**
-     * Decode string if it is base64 encoded, if not, return the original string
+     * Decode string if it is base64 encoded, if not, return the original string.
      *
      * @param string $data
      *
@@ -95,6 +95,17 @@ class Utils
                 $key                       = trim($parts[0]);
                 $value                     = isset($parts[1]) ? trim($parts[1]) : '';
                 $result['headers'][$key][] = $value;
+            } else {
+                // In case the boundary is on next line, after Content-Type
+                // https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
+                if (strpos($line, 'boundary=') !== false) {
+                    foreach ($result['headers'] as $k => &$v) {
+                        if (strtolower($k) == 'content-type') {
+                            $v[0] .= $line;
+                            break;
+                        }
+                    }
+                }
             }
         }
 

--- a/tests/Unit/MimePartTest.php
+++ b/tests/Unit/MimePartTest.php
@@ -89,6 +89,18 @@ class MimePartTest extends TestCase
 
         $this->assertTrue($mimePart->isMultiPart());
         $this->assertEquals($boundary, $mimePart->getParsedHeader('content-type', 0, 'boundary'));
+
+        $mimePart = new MimePart(
+            [
+                'Content-Type' => 'multipart/mixed;
+boundary="' . $boundary . '"',
+            ]
+        );
+        $mimePart->addPart('1');
+        $mimePart->addPart('2');
+
+        $this->assertTrue($mimePart->isMultiPart());
+        $this->assertEquals($boundary, $mimePart->getParsedHeader('content-type', 0, 'boundary'));
     }
 
     public function testBody()


### PR DESCRIPTION
1. /dev/null may not be accessible, so move it to temp file

2. Boundary may be on separated line, so updated Utils::parseMessage

3. PCRE have a limitation of number of lines, so it creates a problem when parses a big file (https://github.com/tiamo/phpas2/issues/26) Moved from Regex to other solution 