### PR TITLE
Change Guzzle Client Options Programmatically 

### DIFF
--- a/src/Management.php
+++ b/src/Management.php
@@ -689,6 +689,17 @@ class Management implements LoggerAwareInterface
 
         return $this->httpClient;
     }
+	
+	/**
+	 * Set Config values for the HTTP Client
+	 *
+	 * @param array $config
+	 * @return void
+	**/
+	public function setHttpClientConfig( array $client_config )
+	{
+		$this->options["client_config"] = $client_config;
+	}
 
     // /**
     //  * @return $this


### PR DESCRIPTION
For Local development where I needed to ignore self-signed certificate errors on `send()` - required the change of a protected property post-manager initialisation.  

``` php
$manager->setHttpClientConfig([ "verify" => false ]);
```
