### PR TITLE
Add return types to MimePart so it works on PHP 8 with the newer version of psr/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^7.1 || ^7.2 || ^7.3 || ^7.4 || ^8.0",
+        "php": "^7.1 || ^7.2 || ^7.3 || ^7.4 || ^8.0 || ^8.1",
         "ext-openssl": "*",
         "ext-zlib": "*",
         "ext-ctype": "*",
@@ -27,7 +27,7 @@
         "psr/log": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^10.3",
         "symfony/var-dumper": "^4.0"
     },
     "autoload": {

--- a/src/CryptoHelper.php
+++ b/src/CryptoHelper.php
@@ -32,7 +32,7 @@ class CryptoHelper
         $digest = base64_encode(
             hash(
                 $digestAlgorithm,
-                $includeHeaders ? $payload : $payload->getBody(),
+                $includeHeaders ? $payload : $payload->getBodyString(),
                 true
             )
         );
@@ -236,7 +236,7 @@ class CryptoHelper
     public static function decompress($data)
     {
         if ($data instanceof MimePart) {
-            $data = $data->getBody();
+            $data = $data->getBodyString();
         }
 
         /** @noinspection CallableParameterUseCaseInTypeContextInspection */

--- a/src/Management.php
+++ b/src/Management.php
@@ -206,7 +206,7 @@ class Management implements LoggerAwareInterface
             $as2headers[$name] = implode(', ', $values);
         }
 
-        $as2Message = new MimePart($as2headers, $payload->getBody());
+        $as2Message = new MimePart($as2headers, $payload->getBodyString());
 
         $message->setHeaders($as2Message->getHeaderLines());
 
@@ -230,7 +230,7 @@ class Management implements LoggerAwareInterface
             ]
         );
 
-        $body = Utils::normalizeBase64($payload->getBody());
+        $body = Utils::normalizeBase64($payload->getBodyString());
 
         // Force encode binary data to base64, `openssl_pkcs7_` doesn't work with binary data
         if (! Utils::decodeBase64($body)) {
@@ -366,7 +366,7 @@ class Management implements LoggerAwareInterface
         try {
             $options = [
                 'headers' => $payload->getHeaders(),
-                'body' => $payload->getBody(),
+                'body' => $payload->getBodyString(),
                 //  'cert' => '' // TODO: partner https cert ?
             ];
 
@@ -452,7 +452,7 @@ class Management implements LoggerAwareInterface
             if ($part->getParsedHeader('content-type', 0, 0) === 'message/disposition-notification') {
                 $this->getLogger()->debug('Found MDN report for message', [$messageId]);
                 try {
-                    $bodyPayload = MimePart::fromString($part->getBody());
+                    $bodyPayload = MimePart::fromString($part->getBodyString());
                     if ($bodyPayload->hasHeader('disposition')) {
                         $mdnStatus = $bodyPayload->getParsedHeader('Disposition', 0, 1);
                         if ($mdnStatus === 'processed') {
@@ -651,7 +651,7 @@ class Management implements LoggerAwareInterface
             $mdn = MimePart::fromString($message->getMdnPayload());
 
             $options = [
-                'body' => $mdn->getBody(),
+                'body' => $mdn->getBodyString(),
                 'headers' => $mdn->getHeaders(),
             ];
 

--- a/src/Server.php
+++ b/src/Server.php
@@ -106,7 +106,7 @@ class Server
                 $origMessageId = null;
                 foreach ($payload->getParts() as $part) {
                     if ($part->getParsedHeader('content-type', 0, 0) === 'message/disposition-notification') {
-                        $bodyPayload = MimePart::fromString($part->getBody());
+                        $bodyPayload = MimePart::fromString($part->getBodyString());
                         $origMessageId = trim($bodyPayload->getParsedHeader('original-message-id', 0, 0), '<>');
                     }
                 }
@@ -164,7 +164,7 @@ class Server
                                 )
                             );
                             $responseHeaders = $mdn->getHeaders();
-                            $responseBody = $mdn->getBody();
+                            $responseBody = $mdn->getBodyString();
                         } else {
                             $this->getLogger()->debug(
                                 sprintf(
@@ -195,7 +195,7 @@ class Server
                 // Build the mdn for the message based on processing status
                 $mdn = $this->manager->buildMdn($message, null, $e->getMessage());
                 $responseHeaders = $mdn->getHeaders();
-                $responseBody = $mdn->getBody();
+                $responseBody = $mdn->getBodyString();
             } else {
                 $responseStatus = 500;
                 $responseBody = $e->getMessage();

--- a/tests/Unit/CryptoHelperTest.php
+++ b/tests/Unit/CryptoHelperTest.php
@@ -91,7 +91,7 @@ class CryptoHelperTest extends TestCase
             'compressed-data',
             $payload->getParsedHeader('content-type', 0, 'smime-type')
         );
-        $body = base64_decode($payload->getBody());
+        $body = base64_decode($payload->getBodyString());
         self::assertEquals(0x30, ord($body[0]));
         self::assertEquals(0x82, ord($body[1]));
         self::assertEquals(0x02, ord($body[2]));
@@ -114,6 +114,6 @@ class CryptoHelperTest extends TestCase
         $payload = CryptoHelper::decompress($payload);
 
         self::assertEquals('Application/EDI-X12', $payload->getHeaderLine('content-type'));
-        self::assertEquals(2247, strlen($payload->getBody()));
+        self::assertEquals(2247, strlen($payload->getBodyString()));
     }
 }

--- a/tests/Unit/ManagementTest.php
+++ b/tests/Unit/ManagementTest.php
@@ -126,7 +126,7 @@ class ManagementTest extends TestCase
 
         $report = $this->management->buildMdn($message);
 
-        self::assertNull($report->getBody());
+        self::assertEmpty($report->getBodyString());
 
         $message->setHeaders('disposition-notification-to: test@example.com');
 
@@ -135,10 +135,10 @@ class ManagementTest extends TestCase
         self::assertTrue($report->isReport());
         self::assertEquals($report->getHeaderLine('as2-to'), $sender->getAs2Id());
         self::assertEquals($report->getHeaderLine('as2-from'), $receiver->getAs2Id());
-        self::assertEquals('custom', trim($report->getPart(0)->getBody()));
+        self::assertEquals('custom', trim($report->getPart(0)->getBodyString()));
 
         $headers = new MimePart(
-            Utils::parseHeaders($report->getPart(1)->getBody())
+            Utils::parseHeaders($report->getPart(1)->getBodyString())
         );
 
         self::assertEquals('<test>', $headers->getHeaderLine('Original-Message-ID'));

--- a/tests/Unit/MimePartTest.php
+++ b/tests/Unit/MimePartTest.php
@@ -92,8 +92,7 @@ class MimePartTest extends TestCase
 
         $mimePart = new MimePart(
             [
-                'Content-Type' => 'multipart/mixed;
-boundary="'.$boundary.'"',
+                'Content-Type' => 'multipart/mixed; boundary="'.$boundary.'"',
             ]
         );
         $mimePart->addPart('1');
@@ -106,13 +105,13 @@ boundary="'.$boundary.'"',
     public function testBody(): void
     {
         $mimePart = MimePart::fromString("content-type:text/plain;\n\ntest");
-        self::assertEquals('test', $mimePart->getBody());
+        self::assertEquals('test', $mimePart->getBodyString());
 
         $mimePart->setBody('test2');
-        self::assertEquals('test2', $mimePart->getBody());
+        self::assertEquals('test2', $mimePart->getBodyString());
 
         $mimePart = MimePart::fromString("content-type:multipart/mixed;\r\n\r\ntest");
-        self::assertEquals('test', $mimePart->getBody());
+        self::assertEquals('test', $mimePart->getBodyString());
 
         $mimePart->setBody(new MimePart([], '1'));
         self::assertEquals(1, $mimePart->getCountParts());
@@ -131,7 +130,7 @@ boundary="'.$boundary.'"',
         self::assertStringStartsWith('application/pkcs7-signature', $mime->getPart(1)->getHeaderLine('content-type'));
         self::assertEquals('application/EDI-Consent', $mime->getPart(0)->getHeaderLine('content-type'));
         self::assertEquals('binary', $mime->getPart(0)->getHeaderLine('Content-Transfer-Encoding'));
-        self::assertStringStartsWith('UNB+UNOA', $mime->getPart(0)->getBody());
+        self::assertStringStartsWith('UNB+UNOA', $mime->getPart(0)->getBodyString());
     }
 
     public function testBodyWithoutHeaders(): void
@@ -139,7 +138,7 @@ boundary="'.$boundary.'"',
         $res = MimePart::fromString($this->loadFixture('test.edi'));
 
         self::assertEmpty($res->getHeaders());
-        self::assertStringStartsWith('UNB+UNOA', $res->getBody());
+        self::assertStringStartsWith('UNB+UNOA', $res->getBodyString());
     }
 
     public function testCreateIfBinaryPartNotBinary(): void

--- a/tests/Unit/ServerTest.php
+++ b/tests/Unit/ServerTest.php
@@ -51,17 +51,17 @@ class ServerTest extends TestCase
         self::assertTrue($report->isReport());
 
         $content = $report->getPart(0);
-        self::assertEquals("Your message was successfully received and processed.\r\n", $content->getBody());
+        self::assertEquals("Your message was successfully received and processed.\r\n", $content->getBodyString());
         self::assertEquals('7bit', $content->getHeaderLine('Content-Transfer-Encoding'));
 
         $disposition = $report->getPart(1);
-        self::assertStringContainsString('Original-Recipient: rfc822; B', $disposition->getBody());
-        self::assertStringContainsString('Original-Recipient: rfc822; B', $disposition->getBody());
-        self::assertStringContainsString('Final-Recipient: rfc822; B', $disposition->getBody());
-        self::assertStringContainsString('Original-Message-ID: <test>', $disposition->getBody());
+        self::assertStringContainsString('Original-Recipient: rfc822; B', $disposition->getBodyString());
+        self::assertStringContainsString('Original-Recipient: rfc822; B', $disposition->getBodyString());
+        self::assertStringContainsString('Final-Recipient: rfc822; B', $disposition->getBodyString());
+        self::assertStringContainsString('Original-Message-ID: <test>', $disposition->getBodyString());
         self::assertStringContainsString('Disposition: automatic-action/MDN-sent-automatically; processed',
-            $disposition->getBody());
-        self::assertStringContainsString('oVDpnrSnpq+V99dXaarQ9HFyRUaFNsp9tdBBSmRhX4s=, sha256', $disposition->getBody());
+            $disposition->getBodyString());
+        self::assertStringContainsString('oVDpnrSnpq+V99dXaarQ9HFyRUaFNsp9tdBBSmRhX4s=, sha256', $disposition->getBodyString());
     }
 
     protected function setUp(): void


### PR DESCRIPTION
The `MimePart` class implements `Psr\Http\Message\MessageInterface` via `guzzlehttp/guzzle` which was recently updated with added return types that cause a "method is not compatible" type error in `MimePart`

This PR adds those return types to `MimePart` so it'll work on PHP 8

All the calling code expects `MimePart::getBody()` to return a string but now it returns a `StreamInterface` so I've updated the calling code in this library to use a new `MimePart::getBodyString()` method - if downstream users depend on strings then use this newer method to get them